### PR TITLE
Work on line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,17 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=lf
+
+# Explicitly declare text files you want to always be normalized and converted
+# to default line endings on checkout.
+*.ind text
+*.yml text
+*.yaml text
+*.R text
+*.Rmd text
+
+# Denote all files that are truly binary and should not be modified.
+*.feather binary
+*.rds binary
+*.png binary
+*.jpg binary
+*.pdf binary

--- a/nawqa_wqp.Rproj
+++ b/nawqa_wqp.Rproj
@@ -14,3 +14,4 @@ LaTeX: pdfLaTeX
 
 AutoAppendNewline: Yes
 StripTrailingWhitespace: Yes
+LineEndingConversion: Posix


### PR DESCRIPTION
Goal: make it so that all git-committed files have LF line endings both in the github repo and on everybody's computers. This helps with shared cache issues when multiple operating systems are in play.

Strategy: change settings for both git and RStudio.

Result: ???

This page https://help.github.com/articles/dealing-with-line-endings/ made it sound like there should have been a lot more changes here, so I'm not sure this PR succeeds in getting us to all-LF on all computers, but it probably doesn't hurt....